### PR TITLE
Set useBuiltIns to "usage" to embed polyfills if needed

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     ["@babel/preset-env", {
-      "useBuiltIns": false,
+      "useBuiltIns": "usage",
       "modules": false,
       "loose": true,
       "shippedProposals": true


### PR DESCRIPTION
None are actually needed, but this prevent things from breaking if one is ever needed.

Enable debug from time to time to check if polyfills are required.